### PR TITLE
add option to write config into file

### DIFF
--- a/tasks/show-config.js
+++ b/tasks/show-config.js
@@ -10,7 +10,7 @@ module.exports = function (grunt) {
     "use strict";
     var desc = "Prints the Grunt configuration object.\nCan optionally add a argument :task to show that task's configuration";
     grunt.registerTask('show-config', desc, function (task) {
-        var configObject;
+        var configObject, target;
         configObject = grunt.config.get();
         if (task) {
             if (configObject[task]) {
@@ -19,6 +19,11 @@ module.exports = function (grunt) {
                 grunt.fatal(task + ' does not have any configurations');
             }
         }
-        grunt.log.writeln(JSON.stringify(configObject, null, 4));
+        if (target = grunt.option('output')) {
+            grunt.log.writeln('Config written to file:', target);
+            grunt.file.write(target, JSON.stringify(configObject, null, 4));
+        } else {
+            grunt.log.writeln(JSON.stringify(configObject, null, 4));
+        }
     });
 };


### PR DESCRIPTION
sometimes it might be useful to write configuration into a file instead of
printing it to stdout.

Consider this use-case:

We have some grunt configuration that defines a lot of targets. There is some
configuration that might be individual for every developer of the project.
We provide some sane defaults for this configuration. In our case, this has been
some `local.conf.defaults.json` file that is loaded by grunt and added as a
local configuration object. All this happens in a npm module, so the developer
doesn't have direct access to this default file.

Now it's possible for a developer to override values
of this configuration in a `local.conf.json` that will never be checked into git.
So if you have a fresh clone, you only got the defaults. To get started
overwriting the configuration with own values, it is great to print the defaults
and write them to `local.conf.json` and just edit this file.
So on the next run, this local configuration is picked up and overwrites parts
of the default configuration with individual things.
